### PR TITLE
add code to handle an empty brush allow another sort-of-traditional way ...

### DIFF
--- a/inst/extdata/eC_brushNguides.js
+++ b/inst/extdata/eC_brushNguides.js
@@ -24,8 +24,7 @@ var activateBrush = function() {
     // brushed = function() { // doesn't work
     // var brushed = function() { // doesn't work
     function brushed() { // Handles the response to brushing
-
-    	var extent = brush.extent() // reports in pixels
+    	var extent = brush.empty() ? [ [ brush.x().domain()[0],brush.y().domain()[0] ], [brush.x().domain()[1],brush.y().domain()[1] ] ] : brush.extent() // reports in pixels
     	var minX = extent[0][0]
     	var maxX = extent[1][0]
     	var minY = extent[0][1]
@@ -50,7 +49,7 @@ var activateBrush = function() {
         brushExtent = [xL, xU, 1-yU, 1-yL] // global variable
     	clearContour();
     	drawContour(xD, yD);
-    } // end of brushed
+    }   // end of brushed
 
 } // end of activateBrush
 


### PR DESCRIPTION
...to reset the brush selection in addition to R button.  This fairly simple changes adds a `brush.empty()` evaluation in `brushed()` to reset the brush if nothing is selected.  I believe this to be standard/expected brush behavior.  This will allow a user the R/reset button or empty brush as two ways to clear the brush.
